### PR TITLE
feat: Add POST-endpoint for Scheduling Availability

### DIFF
--- a/HealthCareABApi/Controllers/ScheduleController.cs
+++ b/HealthCareABApi/Controllers/ScheduleController.cs
@@ -1,0 +1,62 @@
+﻿using HealthCareABApi.DTO;
+using HealthCareABApi.Models;
+using HealthCareABApi.Repositories;
+using HealthCareABApi.Repositories.Implementations;
+using HealthCareABApi.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace HealthCareABApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ScheduleController : ControllerBase
+    {
+        private readonly IAppointmentRepository _appointmentRepository;
+        private readonly IAvailabilityRepository _availabilityRepository;
+
+        public ScheduleController(IAppointmentRepository appointmentRepository, IAvailabilityRepository availabilityRepository)
+        {
+            _appointmentRepository = appointmentRepository; // Repository för bokningar
+            _availabilityRepository = availabilityRepository; // Repository för tillgänglighet
+        }
+
+        // Skapa tillgänglighet för admin
+        [Authorize]
+        [HttpPost("scheduleManagement")]
+        public async Task<IActionResult> ScheduleManagement([FromBody] CreateAvailabilityDTO request)
+        {
+            // Hämta admin-ID från token
+            var caregiverID = User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
+
+            // Returnera Unauthorized om admin inte är inloggad
+            if (string.IsNullOrEmpty(caregiverID))
+            {
+                return Unauthorized(new { error = "User is not authorized or token is missing." });
+            }
+
+            // Skapa en ny tillgänglighetspost
+            var availability = new Availability
+            {
+                CaregiverId = request.CaregiverId,
+                AvailableSlots = request.AvailableSlots
+            };
+
+            // Spara tillgänglighet i databasen
+            await _availabilityRepository.CreateAsync(availability);
+
+            // Returnera 201 Created med detaljer om den nya posten
+            return CreatedAtAction(
+                actionName: nameof(ScheduleManagement),
+                routeValues: new { caregiverId = availability.CaregiverId },
+                value: new
+                {
+                    message = "Availability successfully added",
+                    caregiverId = availability.CaregiverId,
+                    availableSlots = availability.AvailableSlots
+                }
+            );
+        }
+    }
+}

--- a/HealthCareABApi/DTO/AvailabilityDTO.cs
+++ b/HealthCareABApi/DTO/AvailabilityDTO.cs
@@ -4,7 +4,7 @@ namespace HealthCareABApi.DTO
     public class AvailabilityDTO
     {
         public List<DateTime> AvailableSlots { get; set; }
-    }
 
+    }
 }
 


### PR DESCRIPTION
### **I have added a POST endpoint for caregivers where they can add times that they are available for appointment booking.**

**To test:**
1. Check out my branch 39-schedule-management-post-availability

2. Create a user with the role admin and log in with this.
Or log in with my test user:
- Username: testSanna
- Password: testtest
- ID: 677ecf906c34aae0ab08ec69

3. Add a new timeslot by entering the ID and date + time.

4. Check the status message, here you should get status 201 with the status message "Availability successfully added".

5. Check if the time has been added under Availabilities in Atlas.

**_For extra security:_**
1. Log out
2. Try adding a new timeslot again in the same way as in point 3. You should now get error code 400 - Unauthorized