### PR TITLE
22 meeting history return the meeting history

### DIFF
--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -20,6 +20,7 @@ namespace HealthCareABApi.Controllers
             _appointmentService = appointmentService;
         }
 
+
         //börjar med att kolla så användaren är inloggad, annars ska man inte kunna boka tid.
         [Authorize]
         [HttpPost("book")]
@@ -63,5 +64,27 @@ namespace HealthCareABApi.Controllers
 
             return Ok(appointmentDtos);
         }
+
+        [Authorize]
+        [HttpGet("history")]
+        public async Task<IActionResult> GetUserAppointmentHistory()
+        {
+            var userId = User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
+
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized("User ID is missing a token");
+            }
+
+            var appointmentHistory = await _appointmentService.GetAppointmentHistoryForUserAsync(userId);
+
+            if (appointmentHistory == null || !appointmentHistory.Any())
+            {
+                return NotFound("No appointment history found for the user");
+            }
+
+            return Ok(appointmentHistory);
+        }
+
     }
 }

--- a/HealthCareABApi/Models/Appointment.cs
+++ b/HealthCareABApi/Models/Appointment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -20,9 +21,11 @@ namespace HealthCareABApi.Models
 
         public DateTime DateTime { get; set; }
 
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public AppointmentStatus Status { get; set; }
     }
 
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum AppointmentStatus
     {
         Scheduled,
@@ -30,4 +33,3 @@ namespace HealthCareABApi.Models
         Cancelled
     }
 }
-

--- a/HealthCareABApi/Services/AppointmentService.cs
+++ b/HealthCareABApi/Services/AppointmentService.cs
@@ -67,15 +67,24 @@ namespace HealthCareABApi.Services
             // Filtrerar möten till endast historiska (innan nuvarande tid)
             var historicalAppointments = appointments
                 .Where(a => a.DateTime <= DateTime.UtcNow)
-                .Select(appointment => new AppointmentDTO
+                .Select(appointment =>
                 {
-                    CaregiverId = appointment.CaregiverId,
-                    AppointmentTime = appointment.DateTime,
-                    Status = appointment.Status
+                    // Ändra status till Completed om det inte redan är Cancelled
+                    var status = appointment.Status == AppointmentStatus.Cancelled
+                        ? AppointmentStatus.Cancelled
+                        : AppointmentStatus.Completed;
+
+                    return new AppointmentDTO
+                    {
+                        CaregiverId = appointment.CaregiverId,
+                        AppointmentTime = appointment.DateTime,
+                        Status = status
+                    };
                 })
                 .ToList();
 
             return historicalAppointments;
         }
+
     }
 }


### PR DESCRIPTION
- Fetching every meeting where time has passed

- Ajusted upcomingMeeting-endpoint, it now excludes meetings that has passed

- Added JsonConverter in order to show appointmentStatus as Scheduled, Completed and Cancelled instead of 0,1 and 2. 

- Allows query to change all meetings to "completed" 

**Task below will be supplemented via another branch** 

- - Allows query to change all meetings to "completed" exept meetings who's status is "cancelled"
