### PR TITLE
54 bug accounts with admin role can currently book appointments

### DIFF
--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -20,7 +20,6 @@ namespace HealthCareABApi.Controllers
             _appointmentService = appointmentService;
         }
 
-
         //börjar med att kolla så användaren är inloggad, annars ska man inte kunna boka tid.
         [Authorize]
         [HttpPost("bookAppointment")]
@@ -31,7 +30,7 @@ namespace HealthCareABApi.Controllers
 
             if (User.IsInRole("Admin"))
             { 
-                return Unauthorized( new { message = "You are not authorized to book appointments." });
+                return Unauthorized( new { message = "You are not authorized to book appointments as an admin." });
             }
 
             if (string.IsNullOrEmpty(userId))

--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -28,7 +28,7 @@ namespace HealthCareABApi.Controllers
             //Hämtar användarens token mha claims
             var userId = User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
 
-            if (User.IsInRole("Admin"))
+            if (User.IsInRole("admin"))
             { 
                 return Unauthorized( new { message = "You are not authorized to book appointments as an admin." });
             }

--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -29,6 +29,11 @@ namespace HealthCareABApi.Controllers
             //Hämtar användarens token mha claims
             var userId = User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
 
+            if (User.IsInRole("Admin"))
+            { 
+                return Unauthorized( new { message = "You are not authorized to book appointments." });
+            }
+
             if (string.IsNullOrEmpty(userId))
             {
                 return Unauthorized("User ID is missing a token");


### PR DESCRIPTION
Fixed bug by adding errorhandling and a error message.

- I tested this by logging in as an admin and tried to book an appointment, then made sure I was unauthorized. 

- "You are not authorized to book appointments as an admin." should be shown. If someone comes up with a better message, please let me know :)