### PR TITLE
58 enable caregivers to cancel meetings with a httpput method

### DIFF
--- a/HealthCareABApi/Services/AvailabilityService.cs
+++ b/HealthCareABApi/Services/AvailabilityService.cs
@@ -1,6 +1,7 @@
 ﻿using HealthCareABApi.DTO;
 using HealthCareABApi.Models;
 using HealthCareABApi.Repositories;
+using HealthCareABApi.Repositories.Implementations;
 
 namespace HealthCareABApi.Services
 {
@@ -8,9 +9,12 @@ namespace HealthCareABApi.Services
     {
         private readonly IAvailabilityRepository _availabilityRepository;
 
-        public AvailabilityService(IAvailabilityRepository availabilityRepository)
+        private readonly IAppointmentRepository _appointmentRepository;
+
+        public AvailabilityService(IAvailabilityRepository availabilityRepository,IAppointmentRepository appointmentRepository)
         {
             _availabilityRepository = availabilityRepository; // Repository för tillgänglighet
+            _appointmentRepository = appointmentRepository;
         }
 
         public async Task<Availability> CreateAvailabilityAsync(CreateAvailabilityDTO createAvailabilityDTO)
@@ -43,5 +47,33 @@ namespace HealthCareABApi.Services
             return availableSlots;
 
         }
+
+        public async Task<Appointment> UpdateAppointmentStatusAsync(string appointmentId, AppointmentStatus newStatus, bool isAdmin)
+        {
+            // Hämta mötet baserat på ID från repository
+            var appointment = await _appointmentRepository.GetByIdAsync(appointmentId);
+
+            if (appointment == null)
+            {
+                throw new KeyNotFoundException("Appointment not found");
+            }
+
+            // Om användaren är en admin, sätt statusen till 'Cancelled' automatiskt
+            if (isAdmin)
+            {
+                appointment.Status = AppointmentStatus.Cancelled;
+            }
+            else
+            {
+                // Om inte admin, sätt statusen till den angivna värdet
+                appointment.Status = newStatus;
+            }
+
+            // Uppdatera mötet i databasen via repository
+            await _appointmentRepository.UpdateAsync(appointmentId, appointment);
+
+            return appointment;
+        }
+
     }
 }

--- a/HealthCareABApi/Services/AvailabilityService.cs
+++ b/HealthCareABApi/Services/AvailabilityService.cs
@@ -48,7 +48,7 @@ namespace HealthCareABApi.Services
 
         }
 
-        public async Task<Appointment> UpdateAppointmentStatusAsync(string appointmentId, AppointmentStatus newStatus, bool isAdmin)
+        public async Task<Appointment> cancelAppointmentAsync(string appointmentId, AppointmentStatus newStatus, bool isAdmin)
         {
             // Hämta mötet baserat på ID från repository
             var appointment = await _appointmentRepository.GetByIdAsync(appointmentId);


### PR DESCRIPTION
###  HttpPut cancelAppointment

 -  enables admin to cancel meetings 
 -  restricted to admin access only 
 
 **Steps to test**

1. Sign in as "user" and book an appointment
2. Sign is as "admin" and cancel that appointment (use the same appointmentId)
3. Sign in as "user" and navigate to history or upcoming depending on dateTime in order to verify appointment status
