### PR TITLE
64 Personal profile: delete account

### DIFF
--- a/HealthCareABApi/Controllers/UserPagesController.cs
+++ b/HealthCareABApi/Controllers/UserPagesController.cs
@@ -60,5 +60,26 @@ namespace HealthCareABApi.Controllers
             return Ok("User information has been updated");
 
         }
+
+        [HttpDelete("/{userId}")]
+        public async Task<IActionResult> DeleteUser(string userId)
+        {
+            try
+            {
+                var result = await _userPageService.DeleteUserAsync(userId);
+
+                if (!result)
+                {
+                    return NotFound(new { Message = "User not found" });
+                }
+
+                //If we want to send back some information about the deleted user we could use return OK instead of this.
+                return NoContent();
+            }
+            catch(Exception ex) 
+            {
+                return StatusCode(500, new { Message = "An error occured", Details = ex.Message });
+            }
+        }
     }
 }

--- a/HealthCareABApi/Controllers/UserPagesController.cs
+++ b/HealthCareABApi/Controllers/UserPagesController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using HealthCareABApi.DTO;
 using HealthCareABApi.Services;
-using System.Security.Claims;
 
 namespace HealthCareABApi.Controllers
 {
@@ -16,7 +15,7 @@ namespace HealthCareABApi.Controllers
             _userPageService = userPageService;
         }
 
-        [HttpGet("/{userId}")]
+        [HttpGet("/userpage/{userId}")]
         public async Task<IActionResult> GetUser(string userId)
         {
             /* Låter detta ligga kvar. Tidigare lösning som funkade, men kanske inte var optimal?
@@ -46,7 +45,7 @@ namespace HealthCareABApi.Controllers
         }
 
 
-        [HttpPut("/{userId}")]
+        [HttpPut("/userpage/{userId}")]
         public async Task<IActionResult> UpdateUser(string userId, [FromBody] UserDto userDto)
         {
 
@@ -68,7 +67,7 @@ namespace HealthCareABApi.Controllers
             }
         }
 
-        [HttpDelete("/{userId}")]
+        [HttpDelete("/userpage/{userId}")]
         public async Task<IActionResult> DeleteUser(string userId)
         {
             try

--- a/HealthCareABApi/Services/UserPageService.cs
+++ b/HealthCareABApi/Services/UserPageService.cs
@@ -1,4 +1,5 @@
 ﻿using HealthCareABApi.DTO;
+using HealthCareABApi.Models;
 using HealthCareABApi.Repositories;
 
 namespace HealthCareABApi.Services
@@ -6,11 +7,12 @@ namespace HealthCareABApi.Services
     public class UserPageService
     {
         private readonly IUserRepository _userRepository;
+        private readonly IAppointmentRepository _appointmentRepository;
 
-        public UserPageService(IUserRepository userRepository)
+        public UserPageService(IUserRepository userRepository, IAppointmentRepository appointmentRepository)
         {
             _userRepository = userRepository;
-
+            _appointmentRepository = appointmentRepository;
         }
 
         public async Task<UserDto> GetUserInformationAsync(string userId)
@@ -66,6 +68,14 @@ namespace HealthCareABApi.Services
             {
                 return false;
             }
+
+            var userAppointments = await _appointmentRepository.GetByPatientIdAsync(userId);
+            foreach (var appointment in userAppointments)
+            {
+                appointment.Status = AppointmentStatus.Cancelled;
+                await _appointmentRepository.UpdateAsync(appointment.Id, appointment);
+            }
+
             await _userRepository.DeleteAsync(userId);
 
             return true;

--- a/HealthCareABApi/Services/UserPageService.cs
+++ b/HealthCareABApi/Services/UserPageService.cs
@@ -1,5 +1,4 @@
-﻿using HealthCareABApi.Models;
-using HealthCareABApi.DTO;
+﻿using HealthCareABApi.DTO;
 using HealthCareABApi.Repositories;
 
 namespace HealthCareABApi.Services
@@ -59,5 +58,18 @@ namespace HealthCareABApi.Services
             return true;
         }
 
+        public async Task<bool> DeleteUserAsync(string userId)
+        {
+
+            var user = await _userRepository.GetByIdAsync(userId);
+            if (user == null)
+            {
+                return false;
+            }
+            await _userRepository.DeleteAsync(userId);
+
+            return true;
+
+        }
     }
 }

--- a/xUnitTests/AppointmentTest.cs
+++ b/xUnitTests/AppointmentTest.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using HealthCareABApi.Controllers;
-using HealthCareABApi.DTO;
+﻿using HealthCareABApi.DTO;
 using HealthCareABApi.Models;
 using HealthCareABApi.Repositories;
 using HealthCareABApi.Services;
-using Microsoft.AspNetCore.Mvc;
 using Moq;
-using Xunit;
 
 namespace HealthCareABApi.Tests
 {


### PR DESCRIPTION
Added the possibility for a user to delete their account. 
Also updated the controller endpoints to be less obvious, and using the userId as a parameter instead of using claims as we did before. 

How to test:
- Logga in på en befintlig användare (OBS Den kommer tas bort för alltid!). Alternativt registrera en ny: 
- Register a new user
{
  "username": "Ny",
  "password": "nypassword",
  "roles": [
    "user"
  ]
}

- Login
{
  "username": "Ny",
  "password": "nypassword"
}

- Check you user ID in the database.
- Check for booked meetings, if you have none you need to book at least one. Make sure they have status 0 (scheduled) in the database
- Delete your user (Point of no return ;D )
- You should get statuscode 204 - No Content
- Double check the database so your user is deleted and that appointments connected to their ID say status 2 (Cancelled)


Extra: As I have updated the endpoints for getting user information and updating user information, feel free to test these as well. Remember that you have to leave the input field empty like this: "", unless you want all your information to say "string". This is only an issue in swagger. You cannot update role, gender or date of birth in this version of update. 
