### PR TITLE
Using authController to restrict endpoints

### DIFF
--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -1,4 +1,5 @@
 ﻿using HealthCareABApi.DTO;
+using HealthCareABApi.Models;
 using HealthCareABApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -19,7 +20,7 @@ namespace HealthCareABApi.Controllers
         }
 
         //börjar med att kolla så användaren är inloggad, annars ska man inte kunna boka tid.
-        [Authorize]
+        [Authorize(Roles = Roles.User)]
         [HttpPost("bookAppointment")]
         public async Task<IActionResult> BookAppointment([FromBody] AppointmentDTO request)
         {

--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -27,11 +27,6 @@ namespace HealthCareABApi.Controllers
             //Hämtar användarens token mha claims
             var userId = User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
 
-            if (User.IsInRole("admin"))
-            { 
-                return Unauthorized( new { message = "You are not authorized to book appointments as an admin." });
-            }
-
             if (string.IsNullOrEmpty(userId))
             {
                 return Unauthorized("User ID is missing a token");

--- a/HealthCareABApi/Controllers/AvailabilityController.cs
+++ b/HealthCareABApi/Controllers/AvailabilityController.cs
@@ -1,4 +1,5 @@
 ﻿using HealthCareABApi.DTO;
+using HealthCareABApi.Models;
 using HealthCareABApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,18 +19,12 @@ namespace HealthCareABApi.Controllers
         }
 
         // Skapa tillgänglighet för admin
-        [Authorize]
+        [Authorize(Roles = Roles.Admin)]
         [HttpPost("scheduleAvailability")]
         public async Task<IActionResult> ScheduleAvailability([FromBody] CreateAvailabilityDTO request)
         {
             // Hämta admin-ID från token
             var caregiverID = User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
-
-            // Kontrollera att användaren inte är i fel roll (dubbelkontroll)
-            if (!User.IsInRole("admin"))
-            {
-                return Unauthorized(new { message = "Only caregivers are allowed to add availability slots." });
-            }
 
             var createAvailability = await _availabilityService.CreateAvailabilityAsync(request);
 


### PR DESCRIPTION
Removed unnecessary if-statement and added restriction on 

[Authorize(Roles = Roles.User)]
[HttpPost("bookAppointment")]

and

[Authorize(Roles = Roles.Admin)]
[HttpPost("scheduleAvailability")]


**Test API with both user and admin in order to verify restriction**
