### PR TITLE
Fix: Changed to NoContent

### DIFF
--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -55,7 +55,7 @@ namespace HealthCareABApi.Controllers
 
             if (appointmentDtos == null || !appointmentDtos.Any())
             {
-                return NotFound("No appointments found for the user");
+                return NoContent();
             }
 
             return Ok(appointmentDtos);
@@ -75,7 +75,7 @@ namespace HealthCareABApi.Controllers
 
             if (appointmentHistory == null || !appointmentHistory.Any())
             {
-                return NotFound("No appointment history found for the user");
+                return NoContent();
             }
 
             return Ok(appointmentHistory);


### PR DESCRIPTION
When a user does not have an appointment in their history or upcoming, NoContent is returned instead of NotFound