### PR TITLE
95 bug of the year

### DIFF
--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -38,7 +38,7 @@ namespace HealthCareABApi.Controllers
             //Om allt är ok returneras 200.
             return Ok(new
             {
-                caregiverName = caregiverName
+                caregiverName = caregiverName,
                 message = "Appointment successfully booked",
                 appointmentId = appointment.Id,
                 appointmentTime = appointment.DateTime

--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -32,9 +32,13 @@ namespace HealthCareABApi.Controllers
 
             var appointment = await _appointmentService.BookAppointmentAsync(user.Id, request);
 
+            var caregiver = await _userService.GetUserByIdAsync(request.CaregiverId);
+            string caregiverName = caregiver.Username;
+
             //Om allt är ok returneras 200.
             return Ok(new
             {
+                caregiverName = caregiverName
                 message = "Appointment successfully booked",
                 appointmentId = appointment.Id,
                 appointmentTime = appointment.DateTime

--- a/HealthCareABApi/DTO/AppointmentDTO.cs
+++ b/HealthCareABApi/DTO/AppointmentDTO.cs
@@ -6,7 +6,7 @@ namespace HealthCareABApi.DTO
     {
 
         public string CaregiverId { get; set; }
-        public string CaregiverName { get; set; }
+        public string? CaregiverName { get; set; }
         public DateTime AppointmentTime { get; set; }
         public AppointmentStatus Status { get; set; }
 


### PR DESCRIPTION
Made the CaregiverName property nullable so that we don't request it from the user, (but we can still show it in our GET-methods.

Try this by booking an appointment through the interface or Swagger. In swagger you just leave the CaregiverName-field as it is.