### PR TITLE
97 homepage admin   fetch appointment list

### DIFF
--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -86,7 +86,7 @@ namespace HealthCareABApi.Controllers
         }
 
         [Authorize(Roles = Roles.Admin)]
-        [HttpGet("/upcoming/admin/{caregiverId}")]
+        [HttpGet("/admin/{caregiverId}")]
         public async Task<IActionResult> GetAdminAppointments(string caregiverId)
         {
             var user = await _userService.GetUserByIdAsync(caregiverId);

--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -85,5 +85,25 @@ namespace HealthCareABApi.Controllers
             return Ok(appointmentHistory);
         }
 
+        [Authorize(Roles = Roles.Admin)]
+        [HttpGet("/upcoming/admin/{caregiverId}")]
+        public async Task<IActionResult> GetAdminAppointments(string caregiverId)
+        {
+            var user = await _userService.GetUserByIdAsync(caregiverId);
+            if (user == null)
+            {
+                return NotFound($"User with ID {caregiverId} not found.");
+            }
+
+            var appointmentDtos = await _appointmentService.GetAppointmentsForAdminAsync(caregiverId);
+
+            if (appointmentDtos == null || !appointmentDtos.Any())
+            {
+                return NoContent();
+            }
+
+            return Ok(appointmentDtos);
+        }
+
     }
 }

--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -38,7 +38,7 @@ namespace HealthCareABApi.Controllers
             //Om allt är ok returneras 200.
             return Ok(new
             {
-                caregiverName = caregiverName
+                caregiverName = caregiverName,
                 message = "Appointment successfully booked",
                 appointmentId = appointment.Id,
                 appointmentTime = appointment.DateTime

--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -32,9 +32,13 @@ namespace HealthCareABApi.Controllers
 
             var appointment = await _appointmentService.BookAppointmentAsync(user.Id, request);
 
+            var caregiver = await _userService.GetUserByIdAsync(request.CaregiverId);
+            string caregiverName = caregiver.Username;
+
             //Om allt är ok returneras 200.
             return Ok(new
             {
+                caregiverName = caregiverName
                 message = "Appointment successfully booked",
                 appointmentId = appointment.Id,
                 appointmentTime = appointment.DateTime

--- a/HealthCareABApi/DTO/AppointmentDTO.cs
+++ b/HealthCareABApi/DTO/AppointmentDTO.cs
@@ -6,7 +6,7 @@ namespace HealthCareABApi.DTO
     {
 
         public string CaregiverId { get; set; }
-        public string CaregiverName { get; set; }
+        public string? CaregiverName { get; set; }
         public DateTime AppointmentTime { get; set; }
         public AppointmentStatus Status { get; set; }
 

--- a/HealthCareABApi/DTO/AppointmentDTO.cs
+++ b/HealthCareABApi/DTO/AppointmentDTO.cs
@@ -7,6 +7,7 @@ namespace HealthCareABApi.DTO
 
         public string CaregiverId { get; set; }
         public string? CaregiverName { get; set; }
+        public string? PatientName { get; set; }
         public DateTime AppointmentTime { get; set; }
         public AppointmentStatus Status { get; set; }
 

--- a/HealthCareABApi/Repositories/Implementations/AppointmentRepository.cs
+++ b/HealthCareABApi/Repositories/Implementations/AppointmentRepository.cs
@@ -40,6 +40,10 @@ namespace HealthCareABApi.Repositories.Implementations
         {
             return await _collection.Find(a => a.PatientId == patientId).ToListAsync();
         }
+        public async Task<IEnumerable<Appointment>> GetByCaregiverIdAsync(string caregiverId)
+        {
+            return await _collection.Find(a => a.CaregiverId == caregiverId).ToListAsync();
+        }
     }
 }
 

--- a/HealthCareABApi/Repositories/Interfaces/IAppointmentRepository.cs
+++ b/HealthCareABApi/Repositories/Interfaces/IAppointmentRepository.cs
@@ -11,6 +11,7 @@ namespace HealthCareABApi.Repositories
         Task UpdateAsync(string id, Appointment appointment);
         Task DeleteAsync(string id);
         Task<IEnumerable<Appointment>> GetByPatientIdAsync(string patientId);
+        Task<IEnumerable<Appointment>> GetByCaregiverIdAsync(string caregiverId);
 
     }
 }

--- a/HealthCareABApi/Services/AppointmentService.cs
+++ b/HealthCareABApi/Services/AppointmentService.cs
@@ -5,7 +5,7 @@ using HealthCareABApi.Repositories.Implementations;
 
 namespace HealthCareABApi.Services
 {
-    public class AppointmentService 
+    public class AppointmentService
     {
         private readonly IAppointmentRepository _appointmentRepository;
         private readonly IAvailabilityRepository _availabilityRepository;
@@ -98,15 +98,20 @@ namespace HealthCareABApi.Services
         {
             var appointments = await _appointmentRepository.GetByCaregiverIdAsync(caregiverId);
 
-            var upcomingAppointments = new List<AppointmentDTO>();
+            var adminAppointments = new List<AppointmentDTO>();
 
-            foreach (var appointment in appointments.Where(a => a.DateTime > DateTime.UtcNow))
+            foreach (var appointment in appointments)
             {
-                var userId = appointment.PatientId;
 
+                if (appointment.Status != AppointmentStatus.Cancelled)
+                {
+                    appointment.Status = appointment.DateTime < DateTime.UtcNow ? AppointmentStatus.Completed : AppointmentStatus.Scheduled;
+                }
+
+                var userId = appointment.PatientId;
                 var user = await _userRepository.GetByIdAsync(userId);
 
-                upcomingAppointments.Add(new AppointmentDTO
+                adminAppointments.Add(new AppointmentDTO
                 {
                     CaregiverId = caregiverId,
                     PatientName = $"{user.Username}",
@@ -115,9 +120,7 @@ namespace HealthCareABApi.Services
                 });
             }
 
-            return upcomingAppointments;
+            return adminAppointments;
         }
-
-
     }
 }

--- a/HealthCareABApi/Services/AppointmentService.cs
+++ b/HealthCareABApi/Services/AppointmentService.cs
@@ -94,6 +94,30 @@ namespace HealthCareABApi.Services
             return historicalAppointments;
         }
 
+        public async Task<List<AppointmentDTO>> GetAppointmentsForAdminAsync(string caregiverId)
+        {
+            var appointments = await _appointmentRepository.GetByCaregiverIdAsync(caregiverId);
+
+            var upcomingAppointments = new List<AppointmentDTO>();
+
+            foreach (var appointment in appointments.Where(a => a.DateTime > DateTime.UtcNow))
+            {
+                var userId = appointment.PatientId;
+
+                var user = await _userRepository.GetByIdAsync(userId);
+
+                upcomingAppointments.Add(new AppointmentDTO
+                {
+                    CaregiverId = caregiverId,
+                    PatientName = $"{user.Username}",
+                    AppointmentTime = appointment.DateTime,
+                    Status = appointment.Status
+                });
+            }
+
+            return upcomingAppointments;
+        }
+
 
     }
 }


### PR DESCRIPTION
By adding condition within if-statement 

it allows overdue appointments to be completed regarding both admin appointmentList and user appointmentList


Test
If a meeting with the status "scheduled" is overdue, it status should be changed to "completed" automatically
If a meeting with the status "cancelled" is overdue, its supposed to remain "cancelled" after given time as well.

1. Make sure you have booked appointments as admin that contains "scheduled", "completed" and "cancelled"
2. Sign in with that account and make sure its showing the correct status in Get / admin 

